### PR TITLE
Add lint:fix and lint-css:fix scripts to package.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,10 +41,13 @@ jobs:
         run: pnpm check
 
       - name: Lint
-        run: pnpm lint
+        run: pnpm lint:fix
 
       - name: Lint style
-        run: pnpm lint-css
+        run: pnpm lint-css:fix
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
 
       - name: Build
         run: pnpm build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,9 @@
 	"cssvar.ignore": [],
 	"cssvar.extensions": ["css", "jsx", "tsx", "astro"],
 
-	"editor.codeActionsOnSave": { "source.fixAll": true },
+	"editor.codeActionsOnSave": {
+		"source.fixAll": "explicit"
+	},
 	"editor.formatOnSave": true,
 	"editor.quickSuggestions": { "strings": "on" },
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "preview": "astro preview",
     "astro": "astro",
     "lint": "eslint --ext .js,.ts,.astro src",
+    "lint:fix": "eslint --fix --ext .js,.ts,.astro src",
     "lint-css": "stylelint \"**/*.{css,astro}\" --ignore-path .gitignore",
+    "lint-css:fix": "stylelint \"**/*.{css,astro}\" --fix --ignore-path .gitignore",
     "check": "astro check",
     "format": "prettier --write ."
   },

--- a/src/components/TopHeadBlock.astro
+++ b/src/components/TopHeadBlock.astro
@@ -14,10 +14,10 @@ import { NAME } from '../constants'
 <style>
 	.container {
 		display: flex;
+		container-type: inline-size;
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
-		container-type: inline-size;
 	}
 
 	.fluid {

--- a/src/components/TopLinkBlock.astro
+++ b/src/components/TopLinkBlock.astro
@@ -9,12 +9,12 @@
 <style>
 	.container {
 		display: flex;
+		container-type: inline-size;
 		inline-size: 100vw;
 		block-size: 100lvh;
 		flex-direction: column;
 		align-items: center;
 		justify-content: center;
-		container-type: inline-size;
 	}
 
 	a {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -83,11 +83,11 @@
 	}
 
 	:is(p, div, span) > code {
+		padding-inline: var(--size-1);
+		border-radius: var(--size-1);
 		font-family: var(--font-code);
 		color: var(--red-5);
 		background-color: var(--gray-9);
-		border-radius: var(--size-1);
-		padding-inline: var(--size-1);
 	}
 
 	h1,
@@ -97,8 +97,8 @@
 	h5,
 	h6 {
 		letter-spacing: 0.0625em;
-		text-wrap: balance;
 		line-height: 1.3em;
+		text-wrap: balance;
 	}
 
 	h1 {
@@ -116,8 +116,8 @@
 	}
 
 	pre {
-		font-size: var(--font-size-2);
 		padding: var(--size-2);
+		font-size: var(--font-size-2);
 		tab-size: 2;
 
 		@media (768px <= width) {
@@ -126,8 +126,8 @@
 	}
 
 	a {
-		color: var(--gray-0);
 		text-decoration: none;
+		color: var(--gray-0);
 
 		&:is(&:hover, &:focus-visible) {
 			text-decoration: underline;


### PR DESCRIPTION
This pull request adds the `lint:fix` and `lint-css:fix` scripts to the `package.json` file. It also updates the `editor.codeActionsOnSave` setting to use explicit code actions on save. Additionally, it adds write permissions for the `GITHUB_TOKEN` to allow committing and pushing the changed files back to the repository.